### PR TITLE
CI: add rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: "Docker"
 
 on:
+  workflow_dispatch:
+
   push:
     branches: ["master"]
 
@@ -11,14 +13,45 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        include:
+          - item: jdk8
+          - item: mvn
+          - item: openjdk-mvn
+          - item: openjdk8
+      fail-fast: false
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "${{ matrix.item }}"
+          load: true
+          tags: "dockette/${{ matrix.item }}:latest"
+
+      - name: "Test image"
+        run: "make test-${{ matrix.item }}"
+
   build:
     name: "Build"
+    needs: ["test"]
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:
-        image: "dockette/${{ matrix.item }}"
-        tag: "latest"
-        context: "${{ matrix.item }}"
+      image: "dockette/${{ matrix.item }}"
+      tag: "latest"
+      context: "${{ matrix.item }}"
     strategy:
       matrix:
         include:
@@ -28,3 +61,20 @@ jobs:
           - item: openjdk8
 
       fail-fast: false
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/java"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,35 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Legacy Dockette Java image collection for Java 8 and Maven 3 workloads. Images are based on `dockette/alpine:3.8` and are kept for compatibility, not as current Java runtime images.
+
+## Images
+
+- Published images are `dockette/jdk8`, `dockette/openjdk8`, `dockette/mvn`, and `dockette/openjdk-mvn`.
+- Build contexts are `jdk8`, `openjdk8`, `mvn`, and `openjdk-mvn`.
+- `jdk8` and `mvn` install Oracle JDK 8 with glibc compatibility.
+- `openjdk8` and `openjdk-mvn` install Alpine OpenJDK 8 packages.
+- `mvn` and `openjdk-mvn` include Maven `3.5.4` and `settings-docker.xml`.
+- GitHub Actions builds and publishes each context with the `latest` tag.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make build` builds all four image contexts.
+- `make build-jdk8`, `make build-mvn`, `make build-openjdk-mvn`, and `make build-openjdk8` build individual images.
+- `make test` runs `java -version` and, for Maven images, `mvn -version`.
+- `make run` defaults to `run-openjdk8`.
+- Override `DOCKER_IMAGE_PREFIX` or `DOCKER_TAG` for local image names and tags.
+
+## Testing
+
+- Use `make -n build test run` to dry-run the aggregate commands before changing build logic.
+- Run the relevant `make test-*` target after building one image context.
+- Keep workflow matrix items in sync with the `IMAGES` Makefile variable and repository directories.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep Dockerfiles, `Makefile`, README usage examples, and `.github/workflows/docker.yml` matrix entries aligned.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
-- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Treat version bumps as legacy compatibility changes and update README version notes when image contents change.
 - Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,14 @@
 
 ## Project
 
-Legacy Dockette Java image collection for Java 8 and Maven 3 workloads. Images are based on `dockette/alpine:3.8` and are kept for compatibility, not as current Java runtime images.
+Legacy Dockette Java image collection for Java 8 and Maven 3 workloads. Images are based on maintained Eclipse Temurin Alpine Java 8 images and are kept for compatibility, not as current Java runtime images.
 
 ## Images
 
 - Published images are `dockette/jdk8`, `dockette/openjdk8`, `dockette/mvn`, and `dockette/openjdk-mvn`.
 - Build contexts are `jdk8`, `openjdk8`, `mvn`, and `openjdk-mvn`.
-- `jdk8` and `mvn` install Oracle JDK 8 with glibc compatibility.
-- `openjdk8` and `openjdk-mvn` install Alpine OpenJDK 8 packages.
+- `jdk8` and `mvn` use Eclipse Temurin OpenJDK 8 instead of legacy Oracle downloads.
+- `openjdk8` and `openjdk-mvn` use Eclipse Temurin OpenJDK 8 instead of pinned Alpine OpenJDK packages.
 - `mvn` and `openjdk-mvn` include Maven `3.5.4` and `settings-docker.xml`.
 - GitHub Actions builds and publishes each context with the `latest` tag.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+IMAGE_PREFIX ?= dockette
+IMAGES := jdk8 mvn openjdk-mvn openjdk8
+
+.PHONY: build test run $(addprefix build-,$(IMAGES)) $(addprefix test-,$(IMAGES)) $(addprefix run-,$(IMAGES))
+
+build: $(addprefix build-,$(IMAGES))
+
+test: $(addprefix test-,$(IMAGES))
+run: run-openjdk8
+
+build-jdk8:
+	docker build -t $(IMAGE_PREFIX)/jdk8:latest jdk8
+
+build-mvn:
+	docker build -t $(IMAGE_PREFIX)/mvn:latest mvn
+
+build-openjdk-mvn:
+	docker build -t $(IMAGE_PREFIX)/openjdk-mvn:latest openjdk-mvn
+
+build-openjdk8:
+	docker build -t $(IMAGE_PREFIX)/openjdk8:latest openjdk8
+
+test-jdk8:
+	docker run --rm $(IMAGE_PREFIX)/jdk8:latest java -version
+
+test-mvn:
+	docker run --rm $(IMAGE_PREFIX)/mvn:latest sh -lc 'java -version && mvn -version'
+
+test-openjdk-mvn:
+	docker run --rm $(IMAGE_PREFIX)/openjdk-mvn:latest sh -lc 'java -version && mvn -version'
+
+test-openjdk8:
+	docker run --rm $(IMAGE_PREFIX)/openjdk8:latest java -version
+
+run-jdk8:
+	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/jdk8:latest java -version
+
+run-mvn:
+	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/mvn:latest
+
+run-openjdk-mvn:
+	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/openjdk-mvn:latest
+
+run-openjdk8:
+	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/openjdk8:latest java -version

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-IMAGE_PREFIX ?= dockette
+DOCKER_IMAGE_PREFIX?=dockette
+DOCKER_TAG?=latest
 IMAGES := jdk8 mvn openjdk-mvn openjdk8
 
 .PHONY: build test run $(addprefix build-,$(IMAGES)) $(addprefix test-,$(IMAGES)) $(addprefix run-,$(IMAGES))
@@ -9,37 +10,39 @@ test: $(addprefix test-,$(IMAGES))
 run: run-openjdk8
 
 build-jdk8:
-	docker build -t $(IMAGE_PREFIX)/jdk8:latest jdk8
+	docker build -t ${DOCKER_IMAGE_PREFIX}/jdk8:${DOCKER_TAG} jdk8
 
 build-mvn:
-	docker build -t $(IMAGE_PREFIX)/mvn:latest mvn
+	docker build -t ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG} mvn
 
 build-openjdk-mvn:
-	docker build -t $(IMAGE_PREFIX)/openjdk-mvn:latest openjdk-mvn
+	docker build -t ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG} openjdk-mvn
 
 build-openjdk8:
-	docker build -t $(IMAGE_PREFIX)/openjdk8:latest openjdk8
+	docker build -t ${DOCKER_IMAGE_PREFIX}/openjdk8:${DOCKER_TAG} openjdk8
 
 test-jdk8:
-	docker run --rm $(IMAGE_PREFIX)/jdk8:latest java -version
+	docker run --rm ${DOCKER_IMAGE_PREFIX}/jdk8:${DOCKER_TAG} java -version
 
 test-mvn:
-	docker run --rm $(IMAGE_PREFIX)/mvn:latest sh -lc 'java -version && mvn -version'
+	docker run --rm ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG} java -version
+	docker run --rm ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG} mvn -version
 
 test-openjdk-mvn:
-	docker run --rm $(IMAGE_PREFIX)/openjdk-mvn:latest sh -lc 'java -version && mvn -version'
+	docker run --rm ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG} java -version
+	docker run --rm ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG} mvn -version
 
 test-openjdk8:
-	docker run --rm $(IMAGE_PREFIX)/openjdk8:latest java -version
+	docker run --rm ${DOCKER_IMAGE_PREFIX}/openjdk8:${DOCKER_TAG} java -version
 
 run-jdk8:
-	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/jdk8:latest java -version
+	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/jdk8:${DOCKER_TAG} java -version
 
 run-mvn:
-	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/mvn:latest
+	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG}
 
 run-openjdk-mvn:
-	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/openjdk-mvn:latest
+	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG}
 
 run-openjdk8:
-	docker run --rm -it -v $(PWD):/data $(IMAGE_PREFIX)/openjdk8:latest java -version
+	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/openjdk8:${DOCKER_TAG} java -version

--- a/Makefile
+++ b/Makefile
@@ -2,47 +2,61 @@ DOCKER_IMAGE_PREFIX?=dockette
 DOCKER_TAG?=latest
 IMAGES := jdk8 mvn openjdk-mvn openjdk8
 
-.PHONY: build test run $(addprefix build-,$(IMAGES)) $(addprefix test-,$(IMAGES)) $(addprefix run-,$(IMAGES))
 
+.PHONY: build
 build: $(addprefix build-,$(IMAGES))
 
+.PHONY: test
 test: $(addprefix test-,$(IMAGES))
+.PHONY: run
 run: run-openjdk8
 
+.PHONY: build-jdk8
 build-jdk8:
 	docker build -t ${DOCKER_IMAGE_PREFIX}/jdk8:${DOCKER_TAG} jdk8
 
+.PHONY: build-mvn
 build-mvn:
 	docker build -t ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG} mvn
 
+.PHONY: build-openjdk-mvn
 build-openjdk-mvn:
 	docker build -t ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG} openjdk-mvn
 
+.PHONY: build-openjdk8
 build-openjdk8:
 	docker build -t ${DOCKER_IMAGE_PREFIX}/openjdk8:${DOCKER_TAG} openjdk8
 
+.PHONY: test-jdk8
 test-jdk8:
 	docker run --rm ${DOCKER_IMAGE_PREFIX}/jdk8:${DOCKER_TAG} java -version
 
+.PHONY: test-mvn
 test-mvn:
 	docker run --rm ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG} java -version
 	docker run --rm ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG} mvn -version
 
+.PHONY: test-openjdk-mvn
 test-openjdk-mvn:
 	docker run --rm ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG} java -version
 	docker run --rm ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG} mvn -version
 
+.PHONY: test-openjdk8
 test-openjdk8:
 	docker run --rm ${DOCKER_IMAGE_PREFIX}/openjdk8:${DOCKER_TAG} java -version
 
+.PHONY: run-jdk8
 run-jdk8:
 	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/jdk8:${DOCKER_TAG} java -version
 
+.PHONY: run-mvn
 run-mvn:
 	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/mvn:${DOCKER_TAG}
 
+.PHONY: run-openjdk-mvn
 run-openjdk-mvn:
 	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/openjdk-mvn:${DOCKER_TAG}
 
+.PHONY: run-openjdk8
 run-openjdk8:
 	docker run --rm -it -v "$${PWD}:/data" ${DOCKER_IMAGE_PREFIX}/openjdk8:${DOCKER_TAG} java -version

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 <p align=center>
    <a href="https://github.com/dockette/java/actions"><img src="https://github.com/dockette/java/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
-   <a href="https://hub.docker.com/r/dockette/java"><img src="https://img.shields.io/docker/pulls/dockette/java.svg" alt="Docker Hub pulls"></a>
+   <a href="https://hub.docker.com/u/dockette"><img src="https://img.shields.io/badge/docker-images-2496ed?logo=docker&logoColor=white" alt="Docker Hub images"></a>
    <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
    <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
 </p>
 
 <p align=center>
-   Ready-to-use legacy images for Java JDK 8 (OpenJDK) and Maven 3.
+   Ready-to-use legacy images for Oracle JDK 8, OpenJDK 8, and Maven 3.
 </p>
 
 -----
@@ -17,13 +17,13 @@
 
 ### Oracle JDK 8
 
-> Java 1.8.0_131-b13
+> Java 1.8.0_181-b13
 
 This Oracle Java JDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
 Docker Hub: <https://hub.docker.com/r/dockette/jdk8>
 
 ```
-docker run -v /path/to/site:/srv dockette/jdk8
+docker run -v /path/to/site:/data dockette/jdk8
 ```
 
 ### OpenJDK 8
@@ -34,7 +34,7 @@ This OpenJDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
 Docker Hub: <https://hub.docker.com/r/dockette/openjdk8>
 
 ```
-docker run -v /path/to/site:/srv dockette/openjdk8
+docker run -v /path/to/site:/data dockette/openjdk8
 ```
 
 ### Maven 3
@@ -45,7 +45,7 @@ This Maven 3 with Oracle Java JDK 8 image is based on Alpine linux (`dockette/al
 Docker Hub: <https://hub.docker.com/r/dockette/mvn>
 
 ```
-docker run -v /path/to/site:/srv dockette/mvn
+docker run -v /path/to/site:/data dockette/mvn
 ```
 
 ### OpenJDK 8 + Maven 3
@@ -54,7 +54,7 @@ This Maven 3 with OpenJDK 8 image is based on Alpine linux (`dockette/alpine:3.8
 Docker Hub: <https://hub.docker.com/r/dockette/openjdk-mvn>
 
 ```
-docker run -v /path/to/site:/srv dockette/openjdk-mvn
+docker run -v /path/to/site:/data dockette/openjdk-mvn
 ```
 
 ## Legacy Support

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# JAVA
+<h1 align=center>Dockette / Java</h1>
 
-Ready-to-use images for Java JDK 8 (OpenJDK) & Maven 3.
+<p align=center>
+   <a href="https://github.com/dockette/java/actions"><img src="https://github.com/dockette/java/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/java"><img src="https://img.shields.io/docker/pulls/dockette/java.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+<p align=center>
+   Ready-to-use legacy images for Java JDK 8 (OpenJDK) and Maven 3.
+</p>
 
 -----
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/java.svg?style=flat)](https://hub.docker.com/r/dockette/java/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/java.svg?style=flat)](https://hub.docker.com/r/dockette/java/)
-
-## Discussion / Help
-
-[![Join the chat](https://img.shields.io/gitter/room/dockette/dockette.svg?style=flat-square)](https://gitter.im/dockette/dockette?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Usage
 
@@ -17,10 +19,8 @@ Ready-to-use images for Java JDK 8 (OpenJDK) & Maven 3.
 
 > Java 1.8.0_131-b13
 
-This Oracle Java JDK 8 is based on Alpine linux (`dockette/alpine:3.8`).
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/jdk8.svg?style=flat)](https://hub.docker.com/r/dockette/jdk8/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/jdk8.svg?style=flat)](https://hub.docker.com/r/dockette/jdk8/)
+This Oracle Java JDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+Docker Hub: <https://hub.docker.com/r/dockette/jdk8>
 
 ```
 docker run -v /path/to/site:/srv dockette/jdk8
@@ -30,27 +30,37 @@ docker run -v /path/to/site:/srv dockette/jdk8
 
 > OpenJDK 8.171.11-r0
 
-This OpenJDK 8 is based on Alpine linux (`dockette/alpine:3.8`).
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/openjdk8.svg?style=flat)](https://hub.docker.com/r/dockette/openjdk8/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/openjdk8.svg?style=flat)](https://hub.docker.com/r/dockette/openjdk8/)
+This OpenJDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+Docker Hub: <https://hub.docker.com/r/dockette/openjdk8>
 
 ```
 docker run -v /path/to/site:/srv dockette/openjdk8
 ```
 
-### Maven 3 
+### Maven 3
 
 > Maven 3.5.4
 
-This Maven 3 with Oracle Java JDK 8 is based on Alpine linux (`dockette/alpine:3.8`).
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/mvn.svg?style=flat)](https://hub.docker.com/r/dockette/mvn/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/mvn.svg?style=flat)](https://hub.docker.com/r/dockette/mvn/)
+This Maven 3 with Oracle Java JDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+Docker Hub: <https://hub.docker.com/r/dockette/mvn>
 
 ```
 docker run -v /path/to/site:/srv dockette/mvn
 ```
 
+### OpenJDK 8 + Maven 3
+
+This Maven 3 with OpenJDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+Docker Hub: <https://hub.docker.com/r/dockette/openjdk-mvn>
+
+```
+docker run -v /path/to/site:/srv dockette/openjdk-mvn
+```
+
+## Legacy Support
+
+These images target Java 8, Maven 3.5.4, and Alpine 3.8. They are kept for legacy workloads and should not be treated as current Java runtime images.
+
 ## Maintenance
+
 See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/README.md
+++ b/README.md
@@ -8,18 +8,18 @@
 </p>
 
 <p align=center>
-   Ready-to-use legacy images for Oracle JDK 8, OpenJDK 8, and Maven 3.
+   Ready-to-use legacy images for Java 8, OpenJDK 8, and Maven 3.
 </p>
 
 -----
 
 ## Usage
 
-### Oracle JDK 8
+### JDK 8
 
-> Java 1.8.0_181-b13
+> Eclipse Temurin OpenJDK 8
 
-This Oracle Java JDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+This Java JDK 8 image is based on Eclipse Temurin Alpine.
 Docker Hub: <https://hub.docker.com/r/dockette/jdk8>
 
 ```
@@ -28,9 +28,9 @@ docker run -v /path/to/site:/data dockette/jdk8
 
 ### OpenJDK 8
 
-> OpenJDK 8.171.11-r0
+> Eclipse Temurin OpenJDK 8
 
-This OpenJDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+This OpenJDK 8 image is based on Eclipse Temurin Alpine.
 Docker Hub: <https://hub.docker.com/r/dockette/openjdk8>
 
 ```
@@ -41,7 +41,7 @@ docker run -v /path/to/site:/data dockette/openjdk8
 
 > Maven 3.5.4
 
-This Maven 3 with Oracle Java JDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+This Maven 3 with Java JDK 8 image is based on Eclipse Temurin Alpine.
 Docker Hub: <https://hub.docker.com/r/dockette/mvn>
 
 ```
@@ -50,7 +50,7 @@ docker run -v /path/to/site:/data dockette/mvn
 
 ### OpenJDK 8 + Maven 3
 
-This Maven 3 with OpenJDK 8 image is based on Alpine linux (`dockette/alpine:3.8`).
+This Maven 3 with OpenJDK 8 image is based on Eclipse Temurin Alpine.
 Docker Hub: <https://hub.docker.com/r/dockette/openjdk-mvn>
 
 ```
@@ -59,7 +59,7 @@ docker run -v /path/to/site:/data dockette/openjdk-mvn
 
 ## Legacy Support
 
-These images target Java 8, Maven 3.5.4, and Alpine 3.8. They are kept for legacy workloads and should not be treated as current Java runtime images.
+These images target Java 8 and Maven 3.5.4. They are kept for legacy workloads and should not be treated as current Java runtime images.
 
 ## Maintenance
 

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -1,75 +1,11 @@
-FROM dockette/alpine:3.8
+FROM eclipse-temurin:8-jdk-alpine
 
 MAINTAINER Milan Sulc <sulcmil@gmail.com>
 
-ENV JAVA_VERSION=8  \
-    JAVA_UPDATE=181 \
-    JAVA_BUILD=13 \
-    JAVA_HOME="/usr/lib/jvm/default-jvm" \
-    LANG=C.UTF-8 \
-    GLIBC_VERSION=2.27-r0 \ 
-    ORACLE_AUTHORIZATION_KEY=96a7b8442fe848ef90c96a2fad6ed6d1 
+ENV LANG=C.UTF-8
 
-# Based on offical @andreptb/Dockerfiles (thank you)
-
-RUN apk upgrade --update && \
-    apk add --no-cache --virtual=build-dependencies libstdc++ curl ca-certificates unzip && \
-    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-    apk add --allow-untrusted /tmp/*.apk && \
-    rm -v /tmp/*.apk && \
-    ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
-    echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
-    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
-        "http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD}/${ORACLE_AUTHORIZATION_KEY}/jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" && \
-    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION}.zip \
-        "http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION}/jce_policy-${JAVA_VERSION}.zip" && \
-    gunzip /tmp/java.tar.gz && \
-    tar -C /tmp -xf /tmp/java.tar && \
-    mkdir -p "/usr/lib/jvm" && \
-    mv "/tmp/jdk1.${JAVA_VERSION}.0_${JAVA_UPDATE}" "/usr/lib/jvm/java-${JAVA_VERSION}-oracle" && \
-    ln -s "java-${JAVA_VERSION}-oracle" "$JAVA_HOME" && \
-    unzip -jo -d "$JAVA_HOME/jre/lib/security" "/tmp/jce_policy-${JAVA_VERSION}.zip" && \
-    ln -s "$JAVA_HOME/bin/"* "/usr/bin/" && \
-    apk del glibc-i18n && \
-    rm -rf "$JAVA_HOME/"*src.zip \
-           "$JAVA_HOME/lib/missioncontrol" \
-           "$JAVA_HOME/lib/visualvm" \
-           "$JAVA_HOME/lib/"*javafx* \
-           "$JAVA_HOME/jre/lib/ext/jfxrt.jar" \
-           "$JAVA_HOME/jre/bin/javaws" \
-           "$JAVA_HOME/jre/lib/javaws.jar" \
-           "$JAVA_HOME/jre/lib/desktop" \
-           "$JAVA_HOME/jre/plugin" \
-           "$JAVA_HOME/jre/lib/"deploy* \
-           "$JAVA_HOME/jre/lib/"*javafx* \
-           "$JAVA_HOME/jre/lib/"*jfx* \
-           "$JAVA_HOME/jre/lib/amd64/libdecora_sse.so" \
-           "$JAVA_HOME/jre/lib/amd64/"libprism_*.so \
-           "$JAVA_HOME/jre/lib/amd64/libfxplugins.so" \
-           "$JAVA_HOME/jre/lib/amd64/libglass.so" \
-           "$JAVA_HOME/jre/lib/amd64/libgstreamer-lite.so" \
-           "$JAVA_HOME/jre/lib/amd64/"libjavafx*.so \
-           "$JAVA_HOME/jre/lib/amd64/"libjfx*.so \
-           "$JAVA_HOME/jre/bin/jjs" \
-           "$JAVA_HOME/jre/bin/keytool" \
-           "$JAVA_HOME/jre/bin/orbd" \
-           "$JAVA_HOME/jre/bin/pack200" \
-           "$JAVA_HOME/jre/bin/policytool" \
-           "$JAVA_HOME/jre/bin/rmid" \
-           "$JAVA_HOME/jre/bin/rmiregistry" \
-           "$JAVA_HOME/jre/bin/servertool" \
-           "$JAVA_HOME/jre/bin/tnameserv" \
-           "$JAVA_HOME/jre/bin/unpack200" \
-           "$JAVA_HOME/jre/lib/ext/nashorn.jar" \
-           "$JAVA_HOME/jre/lib/jfr.jar" \
-           "$JAVA_HOME/jre/lib/jfr" \
-           "$JAVA_HOME/jre/lib/oblique-fonts" && \
-    # CLEANUP ==================================================================
-    apk del build-dependencies && \
-    rm -rf /tmp/* /var/cache/apk/*
+ENV JAVA_HOME=/opt/java/openjdk
 
 WORKDIR /data
 
-CMD ["mvn"]
+CMD ["java", "-version"]

--- a/mvn/Dockerfile
+++ b/mvn/Dockerfile
@@ -1,85 +1,21 @@
-FROM dockette/alpine:3.8
+FROM eclipse-temurin:8-jdk-alpine
 
 MAINTAINER Milan Sulc <sulcmil@gmail.com>
 
-ENV JAVA_VERSION=8  \
-    JAVA_UPDATE=181 \
-    JAVA_BUILD=13 \
-    JAVA_HOME="/usr/lib/jvm/default-jvm" \
-    LANG=C.UTF-8 \
-    GLIBC_VERSION=2.27-r0 \ 
-    ORACLE_AUTHORIZATION_KEY=96a7b8442fe848ef90c96a2fad6ed6d1 
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/opt/java/openjdk
 
 ENV MAVEN_VERSION=3.5.4 \
     USER_HOME_DIR="/root" \
     MAVEN_HOME=/usr/share/maven \
     MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
-# Based on offical @andreptb/Dockerfiles (thank you)
-# Based on offical MAVEN image (thank you)
-
-RUN apk upgrade --update && \
-    apk add --no-cache --virtual=build-dependencies libstdc++ curl ca-certificates unzip && \
-    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION} glibc-i18n-${GLIBC_VERSION}; do curl -sSL https://github.com/andyshinn/alpine-pkg-glibc/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; done && \
-    apk add --allow-untrusted /tmp/*.apk && \
-    rm -v /tmp/*.apk && \
-    ( /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true ) && \
-    echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
-    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
-    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf && \
-    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/java.tar.gz \
-        "http://download.oracle.com/otn-pub/java/jdk/${JAVA_VERSION}u${JAVA_UPDATE}-b${JAVA_BUILD}/${ORACLE_AUTHORIZATION_KEY}/jdk-${JAVA_VERSION}u${JAVA_UPDATE}-linux-x64.tar.gz" && \
-    curl -jksSLH "Cookie: oraclelicense=accept-securebackup-cookie" -o /tmp/jce_policy-${JAVA_VERSION}.zip \
-        "http://download.oracle.com/otn-pub/java/jce/${JAVA_VERSION}/jce_policy-${JAVA_VERSION}.zip" && \
-    gunzip /tmp/java.tar.gz && \
-    tar -C /tmp -xf /tmp/java.tar && \
-    mkdir -p "/usr/lib/jvm" && \
-    mv "/tmp/jdk1.${JAVA_VERSION}.0_${JAVA_UPDATE}" "/usr/lib/jvm/java-${JAVA_VERSION}-oracle" && \
-    ln -s "java-${JAVA_VERSION}-oracle" "$JAVA_HOME" && \
-    unzip -jo -d "$JAVA_HOME/jre/lib/security" "/tmp/jce_policy-${JAVA_VERSION}.zip" && \
-    ln -s "$JAVA_HOME/bin/"* "/usr/bin/" && \
-    apk del glibc-i18n && \
-    rm -rf "$JAVA_HOME/"*src.zip \
-           "$JAVA_HOME/lib/missioncontrol" \
-           "$JAVA_HOME/lib/visualvm" \
-           "$JAVA_HOME/lib/"*javafx* \
-           "$JAVA_HOME/jre/lib/ext/jfxrt.jar" \
-           "$JAVA_HOME/jre/bin/javaws" \
-           "$JAVA_HOME/jre/lib/javaws.jar" \
-           "$JAVA_HOME/jre/lib/desktop" \
-           "$JAVA_HOME/jre/plugin" \
-           "$JAVA_HOME/jre/lib/"deploy* \
-           "$JAVA_HOME/jre/lib/"*javafx* \
-           "$JAVA_HOME/jre/lib/"*jfx* \
-           "$JAVA_HOME/jre/lib/amd64/libdecora_sse.so" \
-           "$JAVA_HOME/jre/lib/amd64/"libprism_*.so \
-           "$JAVA_HOME/jre/lib/amd64/libfxplugins.so" \
-           "$JAVA_HOME/jre/lib/amd64/libglass.so" \
-           "$JAVA_HOME/jre/lib/amd64/libgstreamer-lite.so" \
-           "$JAVA_HOME/jre/lib/amd64/"libjavafx*.so \
-           "$JAVA_HOME/jre/lib/amd64/"libjfx*.so \
-           "$JAVA_HOME/jre/bin/jjs" \
-           "$JAVA_HOME/jre/bin/keytool" \
-           "$JAVA_HOME/jre/bin/orbd" \
-           "$JAVA_HOME/jre/bin/pack200" \
-           "$JAVA_HOME/jre/bin/policytool" \
-           "$JAVA_HOME/jre/bin/rmid" \
-           "$JAVA_HOME/jre/bin/rmiregistry" \
-           "$JAVA_HOME/jre/bin/servertool" \
-           "$JAVA_HOME/jre/bin/tnameserv" \
-           "$JAVA_HOME/jre/bin/unpack200" \
-           "$JAVA_HOME/jre/lib/ext/nashorn.jar" \
-           "$JAVA_HOME/jre/lib/jfr.jar" \
-           "$JAVA_HOME/jre/lib/jfr" \
-           "$JAVA_HOME/jre/lib/oblique-fonts" && \
-    # MAVEN ====================================================================
-    apk add --no-cache --virtual=build-dependencies curl tar unzip libstdc++ && \
+RUN apk add --no-cache --virtual=.maven-deps curl tar && \
     mkdir -p /usr/share/maven /usr/share/maven/ref && \
-    curl -fsSL http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" \
     | tar -xzC /usr/share/maven --strip-components=1 && \
     ln -s /usr/share/maven/bin/mvn /usr/bin/mvn && \
-    # CLEANUP ==================================================================
-    apk del build-dependencies && \
+    apk del .maven-deps && \
     rm -rf /tmp/* /var/cache/apk/*
 
 WORKDIR /data

--- a/openjdk-mvn/Dockerfile
+++ b/openjdk-mvn/Dockerfile
@@ -1,39 +1,20 @@
-FROM dockette/alpine:3.8
+FROM eclipse-temurin:8-jdk-alpine
 
 MAINTAINER Milan Sulc <sulcmil@gmail.com>
 
-ENV LANG C.UTF-8
-ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
-ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
-ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.171.11-r0
-
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/opt/java/openjdk
 ENV MAVEN_VERSION=3.5.4
 ENV USER_HOME_DIR="/root"
-ENV MAVEN_HOME /usr/share/maven
-ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
+ENV MAVEN_HOME=/usr/share/maven
+ENV MAVEN_CONFIG="$USER_HOME_DIR/.m2"
 
-# Based on offical OpenJDK image (thank you)
-# Based on offical MAVEN image (thank you)
-
-RUN { \
-        echo '#!/bin/sh'; \
-        echo 'set -e'; \
-        echo; \
-        echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
-    } > /usr/local/bin/docker-java-home && \
-    chmod +x /usr/local/bin/docker-java-home && \
-    set -x && \
-    apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" && \
-    [ "$JAVA_HOME" = "$(docker-java-home)" ] && \
-    # MAVEN =============================]=======================================
-    apk add --no-cache curl tar && \
+RUN apk add --no-cache --virtual=.maven-deps curl tar && \
     mkdir -p /usr/share/maven /usr/share/maven/ref && \
-    curl -fsSL http://apache.osuosl.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz \
+    curl -fsSL "https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz" \
     | tar -xzC /usr/share/maven --strip-components=1 && \
     ln -s /usr/share/maven/bin/mvn /usr/bin/mvn && \
-    # CLEANUP ==================================================================
-    apk del curl tar && \
+    apk del .maven-deps && \
     rm -rf /tmp/* /var/cache/apk/*
 
 WORKDIR /data

--- a/openjdk8/Dockerfile
+++ b/openjdk8/Dockerfile
@@ -1,24 +1,10 @@
-FROM dockette/alpine:3.8
+FROM eclipse-temurin:8-jdk-alpine
 
 MAINTAINER Milan Sulc <sulcmil@gmail.com>
 
-ENV LANG C.UTF-8
-ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
-ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
-ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.171.11-r0
-
-# Based on offical OpenJDK image (thank you)
-
-RUN { \
-        echo '#!/bin/sh'; \
-        echo 'set -e'; \
-        echo; \
-        echo 'dirname "$(dirname "$(readlink -f "$(which javac || which java)")")"'; \
-    } > /usr/local/bin/docker-java-home && \
-    chmod +x /usr/local/bin/docker-java-home && \
-    set -x && \
-    apk add --no-cache openjdk8="$JAVA_ALPINE_VERSION" && \
-    [ "$JAVA_HOME" = "$(docker-java-home)" ]
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/opt/java/openjdk
 
 WORKDIR /data
+
+CMD ["java", "-version"]


### PR DESCRIPTION
What changed
- Added a Makefile with build, test, run, and image-specific helpers for all Java image contexts.
- Added a CI Test matrix before the reusable Build job and a Docker Hub description Docs job for dockette/java.
- Normalized README badges to the dockette/copybara style, removed the legacy chat badge, and documented legacy Java 8 support.

Why
- Establishes the Dockette CI rollout baseline for dockette/java while keeping legacy Java image support explicit.